### PR TITLE
Automatically soft-reset charger when ChangeConfiguration returns RebootRequired

### DIFF
--- a/custom_components/givenergy_evc_ocpp/coordinator.py
+++ b/custom_components/givenergy_evc_ocpp/coordinator.py
@@ -1220,6 +1220,9 @@ class GivEnergyEvcCoordinator(DataUpdateCoordinator[GivEnergyEvcState]):
             if key == "SuspevTime":
                 self.data.suspended_state_timeout_seconds = self._coerce_int(value)
 
+        if status == "RebootRequired":
+            await self.async_reset("Soft")
+
         self._publish_state()
         return result
 

--- a/custom_components/givenergy_evc_ocpp/manifest.json
+++ b/custom_components/givenergy_evc_ocpp/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/DJBenson/GivEVC-OCPP/issues",
   "loggers": ["custom_components.givenergy_evc_ocpp"],
-  "version": "0.2.4"
+  "version": "0.2.6"
 }


### PR DESCRIPTION
Automatically soft-reset charger when ChangeConfiguration returns RebootRequired. For example, enabling or disabling the local modbus service requires a restart.